### PR TITLE
Handling of docx4j-ImportXHTML.fonts.default properties

### DIFF
--- a/src/main/java/org/docx4j/convert/in/xhtml/FontHandler.java
+++ b/src/main/java/org/docx4j/convert/in/xhtml/FontHandler.java
@@ -29,10 +29,16 @@ public class FontHandler {
 	static {
 		
 		// Add the defaults
-		ImportXHTMLProperties.getProperty("docx4j-ImportXHTML.fonts.default.serif", "Times New Roman");
-		ImportXHTMLProperties.getProperty("docx4j-ImportXHTML.fonts.default.sans-serif", "Arial");
-		ImportXHTMLProperties.getProperty("docx4j-ImportXHTML.fonts.default.monospace", "Courier New");
-		
+		if(ImportXHTMLProperties.getProperty("docx4j-ImportXHTML.fonts.default.serif")!=null){
+			addFontMapping("serif", ImportXHTMLProperties.getProperty("docx4j-ImportXHTML.fonts.default.serif"));
+		}
+		if(ImportXHTMLProperties.getProperty("docx4j-ImportXHTML.fonts.default.sans-serif")!=null){
+			addFontMapping("sans-serif", ImportXHTMLProperties.getProperty("docx4j-ImportXHTML.fonts.default.sans-serif"));
+		}
+		if(ImportXHTMLProperties.getProperty("docx4j-ImportXHTML.fonts.default.monospace")!=null){
+			addFontMapping("monospace", ImportXHTMLProperties.getProperty("docx4j-ImportXHTML.fonts.default.monospace"));
+		}
+
 		// Add Microsoft ones
 		Map<String, MicrosoftFonts.Font> msFontsByName = MicrosoftFontsRegistry.getMsFonts();
 		for (String cssFontFamily : msFontsByName.keySet()){
@@ -40,6 +46,7 @@ public class FontHandler {
 		}
 	}
 
+	
 	/* Word 2010 Web Options lets you set:
 	 * 
 	 *  proportional font: defaults to TNR 12


### PR DESCRIPTION
The docx4j-ImportXHTML.fonts.default properties (serif, sans-serif,
monospace) had no effect in FontHandler. Now they are added as font
mapping, if existent
