### PR TITLE
Include the "." (dot) in ordered lists just as the default in html does.

### DIFF
--- a/src/main/java/org/docx4j/convert/in/xhtml/ListHelper.java
+++ b/src/main/java/org/docx4j/convert/in/xhtml/ListHelper.java
@@ -238,7 +238,7 @@ public class ListHelper {
 			return "";
 		}
 		
-		return "%"+level;
+		return "%"+level+".";
 	}
 	
 	private RFonts geRFontsForCSSListStyleType(String listStyleType) {


### PR DESCRIPTION
Ordered lists do not contain the "." (dot) character after the number as HTML ordered lists do. 

e.g.

1. one
2. two
3. three

appears in the docx as:
    
1 one
2 two
3 three

This fix just adds the "." character. 