### PR TITLE
fix(junit): testing library should be marked as test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -333,6 +333,7 @@
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.12</version>
+			<scope>test</scope>
 		</dependency>
 	 	
 	</dependencies>


### PR DESCRIPTION
This prevents the junit artifact being included in packaged jars. It's not necessary to include it except when tests are run