### PR TITLE
upgrade to pdfbox 3.0.4 and openhtmltopdf to community fork 1.1.24

### DIFF
--- a/docx4j-ImportXHTML-core/src/main/java/org/docx4j/convert/in/xhtml/renderer/Docx4jDocxOutputDevice.java
+++ b/docx4j-ImportXHTML-core/src/main/java/org/docx4j/convert/in/xhtml/renderer/Docx4jDocxOutputDevice.java
@@ -163,30 +163,6 @@ public class Docx4jDocxOutputDevice extends AbstractOutputDevice {
 	}
 
 	@Override
-	public List<AffineTransform> pushTransforms(List<AffineTransform> transforms) {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-	@Override
-	public void popTransforms(List<AffineTransform> inverse) {
-		// TODO Auto-generated method stub
-		
-	}
-
-	@Override
-	public float getAbsoluteTransformOriginX() {
-		// TODO Auto-generated method stub
-		return 0;
-	}
-
-	@Override
-	public float getAbsoluteTransformOriginY() {
-		// TODO Auto-generated method stub
-		return 0;
-	}
-
-	@Override
 	public void drawBorderLine(Shape bounds, int side, int width, boolean solid) {
 		// TODO Auto-generated method stub
 		
@@ -232,12 +208,6 @@ public class Docx4jDocxOutputDevice extends AbstractOutputDevice {
 	public void popClip() {
 		// TODO Auto-generated method stub
 		
-	}
-
-	@Override
-	public boolean isFastRenderer() {
-		// TODO Auto-generated method stub
-		return false;
 	}
 
 	@Override

--- a/docx4j-ImportXHTML-core/src/main/java/org/docx4j/convert/in/xhtml/renderer/Docx4jUserAgent.java
+++ b/docx4j-ImportXHTML-core/src/main/java/org/docx4j/convert/in/xhtml/renderer/Docx4jUserAgent.java
@@ -20,11 +20,16 @@
  */
 package org.docx4j.convert.in.xhtml.renderer;
 
+import com.openhtmltopdf.outputdevice.helper.ExternalResourceControlPriority;
+import com.openhtmltopdf.outputdevice.helper.ExternalResourceType;
+import com.openhtmltopdf.pdfboxout.PdfBoxImage;
+import com.openhtmltopdf.resource.ImageResource;
+import com.openhtmltopdf.swing.NaiveUserAgent;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-
-import com.openhtmltopdf.swing.NaiveUserAgent;
+import java.util.Locale;
 
 //import com.lowagie.text.Image;
 //import com.lowagie.text.Rectangle;
@@ -72,6 +77,79 @@ public class Docx4jUserAgent extends NaiveUserAgent {
             }
         }
         return null;
+    }
+
+    /**
+     * this method was copied from {@link com.openhtmltopdf.pdfboxout.PdfBoxUserAgent#getImageResource(String, ExternalResourceType)} v1.1.24
+     * and `scaleToOutputResolution(fsImage)`, `_outputDevice.realizeImage(fsImage)` and `XRLog.log(...)` has been commented out
+     */
+    @Override
+    public ImageResource getImageResource(String uriStr, ExternalResourceType type) {
+        if (!checkAccessAllowed(uriStr, type, ExternalResourceControlPriority.RUN_BEFORE_RESOLVING_URI)) {
+            return new ImageResource(uriStr, null);
+        }
+
+        String uriResolved = resolveURI(uriStr);
+
+        if (uriResolved == null) {
+//            XRLog.log(Level.INFO, LogMessageId.LogMessageId2Param.LOAD_URI_RESOLVER_REJECTED_LOADING_AT_URI, "image", uriStr);
+            return new ImageResource(uriStr, null);
+        }
+
+        if (!checkAccessAllowed(uriResolved, type, ExternalResourceControlPriority.RUN_AFTER_RESOLVING_URI)) {
+            return new ImageResource(uriStr, null);
+        }
+
+        ImageResource resource = _imageCache.get(uriResolved);
+
+        if (resource != null && resource.getImage() instanceof PdfBoxImage) {
+            // Make copy of PdfBoxImage so we don't stuff up the cache.
+            PdfBoxImage original = (PdfBoxImage) resource.getImage();
+            PdfBoxImage copy = new PdfBoxImage(original.getBytes(), original.getUri(), original.getWidth(), original.getHeight(), original.getXObject());
+            return new ImageResource(resource.getImageUri(), copy);
+        }
+
+
+        InputStream is = openStream(uriResolved);
+
+        if (is != null) {
+            try {
+                if (uriStr.toLowerCase(Locale.US).endsWith(".pdf")) {
+                    // TODO: Implement PDF AS IMAGE
+                    // PdfReader reader = _outputDevice.getReader(uri);
+                    // PDFAsImage image = new PDFAsImage(uri);
+                    // Rectangle rect = reader.getPageSizeWithRotation(1);
+                    // image.setInitialWidth(rect.getWidth() *
+                    // _outputDevice.getDotsPerPoint());
+                    // image.setInitialHeight(rect.getHeight() *
+                    // _outputDevice.getDotsPerPoint());
+                    // resource = new ImageResource(uriStr, image);
+                } else {
+                    byte[] imgBytes = readStream(is);
+                    PdfBoxImage fsImage = new PdfBoxImage(imgBytes, uriStr);
+                    //scaleToOutputResolution(fsImage);
+                    //_outputDevice.realizeImage(fsImage);
+                    resource = new ImageResource(uriResolved, fsImage);
+                }
+                _imageCache.put(uriResolved, resource);
+            } catch (Exception e) {
+//                XRLog.log(Level.WARNING, LogMessageId.LogMessageId1Param.EXCEPTION_CANT_READ_IMAGE_FILE_FOR_URI, uriStr, e);
+            } finally {
+                try {
+                    is.close();
+                } catch (IOException e) {
+                    // ignore
+                }
+            }
+        }
+
+        if (resource != null) {
+            resource = new ImageResource(resource.getImageUri(), resource.getImage());
+        } else {
+            resource = new ImageResource(uriStr, null);
+        }
+
+        return resource;
     }
 
 //    private void scaleToOutputResolution(Image image) {

--- a/docx4j-ImportXHTML-core/src/main/java/org/docx4j/convert/in/xhtml/renderer/DocxRenderer.java
+++ b/docx4j-ImportXHTML-core/src/main/java/org/docx4j/convert/in/xhtml/renderer/DocxRenderer.java
@@ -46,11 +46,8 @@ import com.openhtmltopdf.render.BlockBox;
 import com.openhtmltopdf.render.PageBox;
 import com.openhtmltopdf.render.ViewportBox;
 import com.openhtmltopdf.simple.extend.XhtmlNamespaceHandler;
-import com.openhtmltopdf.util.Configuration;
-import org.w3c.dom.CharacterData;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import org.w3c.dom.Node;
 
 
 public class DocxRenderer {
@@ -274,6 +271,11 @@ public class DocxRenderer {
 		}
 
 		public boolean isFocus(Element e) {
+			return false;
+		}
+
+		@Override
+		public boolean isMarker(Element element) {
 			return false;
 		}
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -328,14 +328,14 @@
 	<dependencies>
 
 		<dependency>
-			<groupId>com.openhtmltopdf</groupId>
+			<groupId>io.github.openhtmltopdf</groupId>
 			<artifactId>openhtmltopdf-core</artifactId>
-			<version>1.0.10</version>
+			<version>1.1.24</version>
 		</dependency>
 		<dependency>
-			<groupId>com.openhtmltopdf</groupId>
+			<groupId>io.github.openhtmltopdf</groupId>
 			<artifactId>openhtmltopdf-pdfbox</artifactId>
-			<version>1.0.10</version>
+			<version>1.1.24</version>
 			<exclusions>
 				<exclusion>
 		            <groupId>org.apache.pdfbox</groupId>
@@ -376,7 +376,7 @@
 		<dependency>
 			<groupId>org.apache.pdfbox</groupId>
 			<artifactId>pdfbox</artifactId>
-			<version>2.0.30</version>
+			<version>3.0.4</version>
 			<exclusions>
 			  	<!-- use org.slf4j:jcl-over-slf4j instead -->
 				<exclusion>
@@ -393,7 +393,7 @@
 		<dependency>
 			<groupId>org.apache.pdfbox</groupId>
 			<artifactId>xmpbox</artifactId>
-			<version>2.0.24</version>
+			<version>3.0.4</version>
 			<exclusions>
 			  	<!-- use org.slf4j:jcl-over-slf4j instead -->
 				<exclusion>


### PR DESCRIPTION
The original openhtmltopdf project is unmaintained since years and incompatible with pdfbox 3

This PR updates to the comunity fork of openhtmltopdf: https://github.com/openhtmltopdf/openhtmltopdf and to pdfbox 3

fixes https://github.com/plutext/docx4j/issues/600