### PR TITLE
Handle orphan li elements as regular blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Jason Harrop
 Changes in Version 17.0.0
 --------------------------
 
-Align with docx4j 17.0.0 release; handle CyclicStylesException
+Align with docx4j 17.0.0 release.
 
 
 Version 11.5.14 (minor release) 

--- a/docx4j-ImportXHTML-core/src/main/java/org/docx4j/convert/in/xhtml/XHTMLImporterImpl.java
+++ b/docx4j-ImportXHTML-core/src/main/java/org/docx4j/convert/in/xhtml/XHTMLImporterImpl.java
@@ -1320,18 +1320,13 @@ because "this.handler" is null
 				            DON"T TRIGGER THIS LINE
 				        </li>
         			 */
+        			&& listHelper.getDepth()>0
         			&& !(blockBox instanceof com.openhtmltopdf.render.AnonymousBlockBox)) {
 
 	            // Paragraph level styling
             	//P currentP = this.getCurrentParagraph(true);
             	
-        		// You'll get an NPE here if you have li which isn't in ol|ul
-        		try {
-        			listHelper.peekListItemStateStack().init();
-        		} catch (java.lang.NullPointerException ex) {
-        			
-        			throw new RuntimeException("NPE processing list item.  This is likely because you have an <li> which isn't in an <ol> or <ul>. "); 
-        		}
+        		listHelper.peekListItemStateStack().init();
             	
                 PPr pPr =  Context.getWmlObjectFactory().createPPr();
                 this.getCurrentParagraph(true).setPPr(pPr);


### PR DESCRIPTION
Some input HTML may contain invalid list markup, such as li elements that are not wrapped in an ol or ul. Previously, this could cause list state initialization to fail, interrupting the entire XHTML import flow.

Would it make sense to handle this case more leniently by only applying list numbering logic when the importer is actually inside a list context? With this change, orphan li elements fall back to regular block handling instead of propagating an exception, while valid list items inside ol/ul continue to use the existing numbering logic.